### PR TITLE
Valid HAProxy configuration for Ubuntu Trusty

### DIFF
--- a/transformers/tests/haproxy-cfg.expected
+++ b/transformers/tests/haproxy-cfg.expected
@@ -5,7 +5,7 @@ global
   group haproxy
   maxconn 4096
   log logs.papertrailapp.com:45187 local0
-  log logs.papertrailapp.com:45187 local1 notice error
+  log logs.papertrailapp.com:45187 local1 emerg notice
 
 defaults
   log global
@@ -48,8 +48,8 @@ backend websocket
   timeout queue 5000
   timeout server 86400000
   option httpchk GET /ws-healthcheck HTTP/1.0
-  server socket10 localhost:6010 maxconn 10000 check inter
+  server socket10 localhost:6010 maxconn 10000 check inter 20s
   server socket11 localhost:6011 maxconn 10000 check backup
   server socket12 localhost:6012 maxconn 10000 check inter 5000
-  server socket13 localhost:6013 maxconn 10000 check source 192.168.0.5:80 usesrc client
-  server socket14 localhost:6014 maxconn 10000 check source 192.168.0.5:80 usesrc hdr_ip(x-forwarded-for,-1)
+  server socket13 localhost:6013 maxconn 10000 check source 192.168.0.5:80 interface lo
+  server socket14 localhost:6014 maxconn 10000 check source 192.168.0.5:80 interface eth0

--- a/transformers/tests/haproxy-cfg.json
+++ b/transformers/tests/haproxy-cfg.json
@@ -7,7 +7,7 @@
     "maxconn": 4096,
     "log": [
       ["logs.papertrailapp.com:45187", "local0"],
-      ["logs.papertrailapp.com:45187", "local1", "notice", "error"]
+      ["logs.papertrailapp.com:45187", "local1", "emerg", "notice"]
     ]
   },
   "defaults": {
@@ -81,11 +81,11 @@
         "httpchk": ["GET", "/ws-healthcheck", "HTTP/1.0"]
       },
       "server": {
-        "socket10": ["localhost:6010", {"maxconn": 10000, "check": true, "inter": true}],
+        "socket10": ["localhost:6010", {"maxconn": 10000, "check": true, "inter": "20s"}],
         "socket11": ["localhost:6011", {"maxconn": 10000, "check": true, "backup": true}],
         "socket12": ["localhost:6012", {"maxconn": 10000, "check": true, "inter": 5000}],
-        "socket13": ["localhost:6013", {"maxconn": 10000, "check": true, "source": ["192.168.0.5:80", {"usesrc": "client"}]}],
-        "socket14": ["localhost:6014", {"maxconn": 10000, "check": true, "source": ["192.168.0.5:80", {"usesrc": "hdr_ip(x-forwarded-for,-1)"}]}]
+        "socket13": ["localhost:6013", {"maxconn": 10000, "check": true, "source": ["192.168.0.5:80", {"interface": "lo"}]}],
+        "socket14": ["localhost:6014", {"maxconn": 10000, "check": true, "source": ["192.168.0.5:80", {"interface": "eth0"}]}]
       }
     }
   }


### PR DESCRIPTION
Some minor tweaks to the HAProxy test configuration to pass checks (`haproxy -c -f transformers/tests/haproxy-cfg.expected`) on Ubuntu Trusty version of HAProxy.
