### PR TITLE
Support negated options for HAProxy transformer

### DIFF
--- a/transformers/haproxy-cfg
+++ b/transformers/haproxy-cfg
@@ -35,7 +35,7 @@ def arg(obj)
 		obj.collect{|a| arg(a) }.join " "
 	when Hash
 		obj.collect{|k,v| [k, arg(v)].join(" ") }.join " "
-	when TrueClass, NilClass
+	when TrueClass, NilClass, FalseClass
 		""
 	when Fixnum, Float
 		obj.to_s
@@ -50,7 +50,7 @@ def keyword(name, args)
 	if args.is_a? Hash
 		args.collect do |k,v|
 			if v == false
-				nil # in other words, drop the whole keyword line (using compact)
+				keyword("no #{name} #{k}", v)
 			else
 				keyword("#{name} #{k}", v)
 			end

--- a/transformers/tests/haproxy-cfg.expected
+++ b/transformers/tests/haproxy-cfg.expected
@@ -12,6 +12,7 @@ defaults
   mode http
   option httplog
   option dontlognull
+  option http-tunnel
   timeout connect 5000
   timeout client 50s
   timeout server 1m
@@ -40,6 +41,7 @@ backend appin
   timeout queue 5000
   timeout server 50000
   option forwardfor header X-Client
+  no option http-tunnel
   server socket0 localhost:6000 maxconn 500 check
   server socket1 localhost:6001 maxconn 500 check
 

--- a/transformers/tests/haproxy-cfg.json
+++ b/transformers/tests/haproxy-cfg.json
@@ -15,7 +15,8 @@
     "mode": "http",
     "option": {
       "httplog": true,
-      "dontlognull": true
+      "dontlognull": true,
+      "http-tunnel": true
     },
     "timeout": {
       "connect": 5000,
@@ -64,7 +65,8 @@
         "server": 50000
       },
       "option": {
-        "forwardfor": ["header", "X-Client"]
+        "forwardfor": ["header", "X-Client"],
+        "http-tunnel": false
       },
       "server": {
         "socket0": ["localhost:6000", "maxconn", 500, "check"],


### PR DESCRIPTION
Allows options to be set `false` which will prefix them with `no`.
