### PR TITLE
Adding cmdRunner field to Copy(). Fixes #4

### DIFF
--- a/config.go
+++ b/config.go
@@ -175,6 +175,7 @@ func (c *Config) Copy() *Config {
 		reloadCmd:    c.reloadCmd,
 		validateCmd:  c.validateCmd,
 		store:        c.store,
+		cmdRunner:    c.cmdRunner,
 	}
 }
 


### PR DESCRIPTION
A previous [commit](https://github.com/progrium/configurator/commit/8777f79c8d7d3e85106823ace120063d95011b5e#diff-b4bda758a2aef091432646c354b4dc59R46) introduced the `cmdRunner` field but the `Copy()` method missed it.
## Testing this pull-req

With [Dockerfile](https://gist.github.com/lalyos/075ff4b62c9ae5145109#file-dockerfile) referenced from Issue #4 you can test any repo/branch:

```
docker run --rm \
  -e REPO=github.com/lalyos/configurator \
  -e BRANCH=nil-pointer-dereference \
  configurator-test
```
